### PR TITLE
Fix data fetch path for recent products

### DIFF
--- a/pages/current.js
+++ b/pages/current.js
@@ -17,8 +17,10 @@
     };
     
     // GitHub 저장소 설정
-    const PRODUCTS_DATA_URL = 'https://jacob-po.github.io/products-data/products.json';
-    const CONFIG_DATA_URL = 'https://jacob-po.github.io/nofee-webflow/data/config.json';
+    const basePath = window.location.pathname.startsWith('/nofee-webflow') ? '/nofee-webflow' : '';
+    const GITHUB_BASE_URL = window.location.origin + basePath;
+    const PRODUCTS_DATA_URL = `${GITHUB_BASE_URL}/data/products.json`;
+    const CONFIG_DATA_URL = `${GITHUB_BASE_URL}/data/config.json`;
     
     // DOM 요소 캐싱
     let elements = {};


### PR DESCRIPTION
## Summary
- avoid cross-origin requests by fetching JSON data from the same origin in `pages/current.js`

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_683cef4464ac832b9302afcccc5285aa