### PR TITLE
Remove blur effect from main embed

### DIFF
--- a/embed/main-embed.html
+++ b/embed/main-embed.html
@@ -267,7 +267,6 @@
 
         .feature-badge {
             background: rgba(255, 255, 255, 0.9);
-            backdrop-filter: blur(20px);
             border: 1px solid rgba(255, 255, 255, 0.2);
             padding: 12px 20px;
             border-radius: var(--radius-full);
@@ -293,7 +292,6 @@
         /* 🚀 Hero Banner */
         .hero-banner {
             background: rgba(255, 255, 255, 0.95);
-            backdrop-filter: blur(20px);
             border: 1px solid rgba(255, 255, 255, 0.2);
             border-radius: var(--radius-2xl);
             overflow: hidden;
@@ -459,7 +457,6 @@
             align-items: center;
             gap: 8px;
             background: rgba(255, 255, 255, 0.25);
-            backdrop-filter: blur(20px);
             padding: 6px 16px;
             border-radius: var(--radius-full);
             font-size: 14px;
@@ -505,7 +502,6 @@
 
         .feature-tag {
             background: rgba(255, 255, 255, 0.2);
-            backdrop-filter: blur(20px);
             padding: 8px 12px;
             border-radius: var(--radius);
             font-size: 14px;
@@ -538,7 +534,6 @@
         /* 📊 실시간 통계 섹션 */
         .stats-dashboard {
             background: rgba(255, 255, 255, 0.95);
-            backdrop-filter: blur(20px);
             border: 1px solid rgba(255, 255, 255, 0.2);
             border-radius: var(--radius-2xl);
             padding: 32px;
@@ -554,7 +549,6 @@
 
         .stat-card {
             background: rgba(255, 255, 255, 0.8);
-            backdrop-filter: blur(20px);
             border: 1px solid rgba(255, 255, 255, 0.3);
             border-radius: var(--radius-xl);
             padding: 24px;
@@ -632,7 +626,6 @@
         /* 🏆 Best Products - 개선된 버전 */
         .best-products {
             background: rgba(255, 255, 255, 0.95);
-            backdrop-filter: blur(20px);
             border: 1px solid rgba(255, 255, 255, 0.2);
             border-radius: var(--radius-2xl);
             padding: 32px;
@@ -647,7 +640,6 @@
 
         .product-card {
             background: rgba(255, 255, 255, 0.9);
-            backdrop-filter: blur(20px);
             border: 1px solid rgba(255, 255, 255, 0.3);
             border-radius: var(--radius-xl);
             padding: 28px;
@@ -869,7 +861,6 @@
         /* 📈 요금제 비교 도구 */
         .plan-comparison {
             background: rgba(255, 255, 255, 0.95);
-            backdrop-filter: blur(20px);
             border: 1px solid rgba(255, 255, 255, 0.2);
             border-radius: var(--radius-2xl);
             padding: 32px;
@@ -955,7 +946,6 @@
         /* 📱 Reviews */
         .reviews-section {
             background: rgba(255, 255, 255, 0.95);
-            backdrop-filter: blur(20px);
             border: 1px solid rgba(255, 255, 255, 0.2);
             border-radius: var(--radius-2xl);
             padding: 32px;
@@ -1042,7 +1032,6 @@
         .review-card {
             flex: 0 0 300px;
             background: rgba(255, 255, 255, 0.8);
-            backdrop-filter: blur(20px);
             border: 1px solid rgba(255, 255, 255, 0.3);
             border-radius: var(--radius-xl);
             padding: 24px;


### PR DESCRIPTION
## Summary
- remove all `backdrop-filter: blur(20px)` rules from **main-embed.html** to keep the page crisp

## Testing
- `grep -n "backdrop-filter" embed/main-embed.html`

------
https://chatgpt.com/codex/tasks/task_b_684017ddd044832bbcfaa08922e96585